### PR TITLE
indent docs so they show up properly

### DIFF
--- a/src/Json/Decode/Extra.elm
+++ b/src/Json/Decode/Extra.elm
@@ -89,23 +89,23 @@ apply f aDecoder =
 
 {-| Infix version of `apply` that makes for a nice DSL when decoding objects:
 
-locationDecoder : Decoder Location
-locationDecoder =
-    succeed Location
-        |: ("id" := int)
-        |: ("name" := string)
-        |: ("address" := string)
-        |: ("city" := string)
-        |: ("state" := string)
+    locationDecoder : Decoder Location
+    locationDecoder =
+        succeed Location
+            |: ("id" := int)
+            |: ("name" := string)
+            |: ("address" := string)
+            |: ("city" := string)
+            |: ("state" := string)
 
 
-type alias Location =
-    { id : Int
-    , name : String
-    , address : String
-    , city : String
-    , state : String
-    }
+    type alias Location =
+        { id : Int
+        , name : String
+        , address : String
+        , city : String
+        , state : String
+        }
 
 -}
 (|:) : Decoder (a -> b) -> Decoder a -> Decoder b


### PR DESCRIPTION
Docs for `|:` are not being formatted correctly, which I assume is because the code blocks aren't indented.

<img width="799" alt="screen shot 2015-12-16 at 4 49 55 pm" src="https://cloud.githubusercontent.com/assets/72027/11857396/1bf68694-a415-11e5-90b7-39e879720330.png">

This indents them so they show up properly.
