### PR TITLE
apply = object2 (<|)

### DIFF
--- a/src/Json/Decode/Extra.elm
+++ b/src/Json/Decode/Extra.elm
@@ -83,8 +83,8 @@ This is a shortened form of
 
 -}
 apply : Decoder (a -> b) -> Decoder a -> Decoder b
-apply f aDecoder =
-  f `andThen` (\f' -> f' `map` aDecoder)
+apply =
+  object2 (<|)
 
 
 {-| Infix version of `apply` that makes for a nice DSL when decoding objects:


### PR DESCRIPTION
This is an alternative implementation for `apply` for your consideration. I think it's aesthetically nice (draws attention to the fact that this is somehow a lifted version of regular function application) and _might_ be faster due to less function calls (?), but I haven't benchmarked it. This implementation would probably be a bit more clear if `object2` were called `map2` as in other libraries, but I think it's still pretty good.

Cheers,
James
