### PR TITLE
Fix date docs

### DIFF
--- a/src/Json/Decode/Extra.elm
+++ b/src/Json/Decode/Extra.elm
@@ -212,17 +212,6 @@ date =
   customDecoder string Date.fromString
 
 
-
--- {-| Extract a time value.
---
--- Note that this function is not total, it will throw an exception given an incorrectly formatted time value.
--- See `Time.fromString` and `Json.customDecoder`.
---
--- -}
--- time : Decoder Time.Time
--- time = customDecoder string (Date.fromString >> Date.toTime)
-
-
 {-| Extract a set.
 -}
 set : Decoder comparable -> Decoder (Set comparable)

--- a/src/Json/Decode/Extra.elm
+++ b/src/Json/Decode/Extra.elm
@@ -201,11 +201,7 @@ We win!
   apply
 
 
-{-| Extract a date.
-
-Note that this function is not total, it will throw an exception given an incorrectly formatted date.
-See `Date.fromString` and `Json.customDecoder`.
-
+{-| Extract a date using [`Date.fromString`](http://package.elm-lang.org/packages/elm-lang/core/latest/Date#fromString)
 -}
 date : Decoder Date.Date
 date =


### PR DESCRIPTION
The warning about `date` being not total is not accurate. That function was introduced back in `core` 1.0.0, so maybe it was true back then because of some sort of crash bug then?
